### PR TITLE
Setup landscape docs redirect and update navigation link

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -40,4 +40,4 @@ search/?$: https://www.ubuntu.com/search
 # core, phone subdomains
 (?P<project>(core|phone))(/en)?/?(?P<path>.*): https://{project}.docs.ubuntu.com/en/{path}
 
-landscape/en/?: https://www.ubuntu.com/landscape/docs
+landscape/en/(?P<path>.*)/?: https://www.ubuntu.com/landscape/docs/{path}

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -39,3 +39,5 @@ search/?$: https://www.ubuntu.com/search
 
 # core, phone subdomains
 (?P<project>(core|phone))(/en)?/?(?P<path>.*): https://{project}.docs.ubuntu.com/en/{path}
+
+landscape/en/?: https://www.ubuntu.com/landscape/docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ django-template-finder-view==0.3
 django-yaml-redirects==0.5.4
 talisker[gunicorn,gevent]==0.19.0
 whitenoise==5.3.0
-ubuntudesign.documentation-builder==1.6.5
+git+https://github.com/canonical/documentation-builder@python-3.10-updates#egg=ubuntudesign.documentation-builder
 gitdb2==3.0.3.post1
 MarkupSafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ django-template-finder-view==0.3
 django-yaml-redirects==0.5.4
 talisker[gunicorn,gevent]==0.19.0
 whitenoise==5.3.0
-git+https://github.com/canonical/documentation-builder@python-3.10-updates#egg=ubuntudesign.documentation-builder
+ubuntudesign.documentation-builder==1.7.0
 gitdb2==3.0.3.post1
 MarkupSafe==2.0.1

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,7 +77,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/4964d639-landscape-logo.svg" alt="Landscape">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://docs.ubuntu.com/landscape/en/">Landscape&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://ubuntu.com/landscape/docs">Landscape&nbsp;</a></h3>
             <div class="p-matrix__desc">
               <p>Systems management for Ubuntu - updates, package management, repositories, security</p>
             </div>


### PR DESCRIPTION
## Done

- Setup landscape docs redirect and update navigation link to the new ubuntu.com hosted docs

## QA

- Go to https://docs-ubuntu-com-350.demos.haus/landscape/en/ and see that you are redirected to https://ubuntu.com/landscape/docs
- Go to the home pages of https://docs-ubuntu-com-350.demos.haus/ and click the link for `Landscape`, see that it take you to https://ubuntu.com/landscape/docs

