### PR TITLE
Update redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,8 +13,10 @@ conjure-up/(?P<page>.*): https://docs.conjure-up.io/{page}
 snap-enterprise-proxy: /snap-store-proxy/en/
 snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 
-# Landsacpe
+# Landscape
 landscape/en/?: https://ubuntu.com/landscape/docs
+landscape/en/landscape-api/?: /landscape/en/api
+landscape/en/onprem-overview/?: /landscape/en/onprem
 
 # Documentation-builder
 documentation-builder/?: https://github.com/canonical-webteam/documentation-builder/tree/master/docs

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -14,8 +14,7 @@ snap-enterprise-proxy: /snap-store-proxy/en/
 snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 
 # Landsacpe
-landscape/en/landscape-api/?: /landscape/en/api
-landscape/en/onprem-overview/?: /landscape/en/onprem
+landscape/en/?: https://ubuntu.com/landscape/docs
 
 # Documentation-builder
 documentation-builder/?: https://github.com/canonical-webteam/documentation-builder/tree/master/docs


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

https://docs-ubuntu-com-355.demos.haus/landscape/en/ should redirect to https://ubuntu.com/landscape/docs

Test that these links redirect correctly

https://docs-ubuntu-com-355.demos.haus/landscape/en/concepts → https://ubuntu.com/landscape/docs

https://docs-ubuntu-com-355.demos.haus/landscape/en/onprem → https://ubuntu.com/landscape/docs/self-hosted-landscape 

https://docs-ubuntu-com-355.demos.haus/landscape/en/landscape-install-quickstart  → https://ubuntu.com/landscape/docs/quickstart-deployment 

https://docs-ubuntu-com-355.demos.haus/landscape/en/landscape-install-manual → https://ubuntu.com/landscape/docs/manual-installation 

https://docs-ubuntu-com-355.demos.haus/landscape/en/onprem-backup → https://ubuntu.com/landscape/docs/backup-and-restore 

https://docs-ubuntu-com-355.demos.haus/landscape/en/onprem-logs → https://ubuntu.com/landscape/docs/logs 

https://docs-ubuntu-com-355.demos.haus/landscape/en/onprem-auth → https://ubuntu.com/landscape/docs/external-authentication 

https://docs-ubuntu-com-355.demos.haus/landscape/en/api-client-package → https://ubuntu.com/landscape/docs/command-line-client 

https://docs-ubuntu-com-355.demos.haus/landscape/en/api-http-requests → https://ubuntu.com/landscape/docs/low-level-http-requests 

https://docs-ubuntu-com-355.demos.haus/landscape/en/api-methods → https://ubuntu.com/landscape/docs/api-overview

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2513?atlOrigin=eyJpIjoiYTIwOTg1YmEyZGUyNDZlYTk5OWM1YWViYTgyYzBhYzUiLCJwIjoiaiJ9
