### PR TITLE
WD-2513 redirect landscape old docs to new docs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -15,8 +15,10 @@ snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 
 # Landscape
 landscape/en/?: https://ubuntu.com/landscape/docs
+landscape/en/: https://ubuntu.com/landscape/docs
 landscape/en/landscape-api/?: /landscape/en/api
 landscape/en/onprem-overview/?: /landscape/en/onprem
+landscape/en/landscape-install-quickstart/?: https://ubuntu.com/landscape/docs/quickstart-deployment
 
 # Documentation-builder
 documentation-builder/?: https://github.com/canonical-webteam/documentation-builder/tree/master/docs


### PR DESCRIPTION
## Done

Add more redirects to move landscape documentation according to https://warthogs.atlassian.net/browse/WD-2513

## QA
Check:
- https://docs-ubuntu-com-357.demos.haus/landscape/en/  redirects to https://ubuntu.com/landscape/docs
- https://docs-ubuntu-com-357.demos.haus/landscape/en/landscape-install-quickstart  redirects to https://ubuntu.com/landscape/docs/quickstart-deployment



## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-2513
Closes https://warthogs.atlassian.net/browse/WD-3003
