### PR TITLE
Update Snap Store Proxy link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -90,7 +90,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Snapcraft Proxy">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="/snap-store-proxy/en">Snap Store Proxy&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://canonical-snap-store-proxy.readthedocs-hosted.com/en/latest">Snap Store Proxy&nbsp;</a></h3>
             <div class="p-matrix__desc">
               <p>The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
             </div>


### PR DESCRIPTION
## Done

- Update link for Snap Store Proxy
- Copy update request: https://docs.google.com/document/d/1mcfPYByoIT_iFOot6fxqq_bXX9p9vENWkLt4-ZI22Qg/edit#heading=h.kirb2ro8pwcn

## QA
- Go to landing
- See that "Snap Store Proxy" redirects to https://canonical-snap-store-proxy.readthedocs-hosted.com/en/latest/

## Issue / Card

Fixes [WD-13621](https://warthogs.atlassian.net/browse/WD-13621)

## Screenshots

[if relevant, include a screenshot]


[WD-13621]: https://warthogs.atlassian.net/browse/WD-13621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ