### PR TITLE
Remove snap store proxy generation and adds redirects

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -61,27 +61,6 @@ build_docs () {
                             --tag-manager-code "GTM-KNX3CJC"  \
                             --no-link-extensions
     fi
-
-
-    # Snap Store Proxy docs
-    folder="build/snap-store-proxy"
-    name="snap-store-proxy"
-    repo_url="https://github.com/canonical-ols/snapstore-snap-docs.git"
-
-    if ! up_to_date ${folder} ${repo_url}; then
-      refresh_repo ${folder} ${repo_url} main
-
-      documentation-builder --base-directory "${folder}"  \
-                            --site-root "/${name}/"  \
-                            --output-path "templates/${name}"  \
-                            --output-media-path "static/media/${name}"  \
-                            --search-url "/search"  \
-                            --search-placeholder "Search Snap Store Proxy docs"  \
-                            --search-domain "docs.ubuntu.com/${name}"  \
-                            --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-KNX3CJC"  \
-                            --no-link-extensions
-    fi
 }
 
 build_docs

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -10,8 +10,11 @@ conjure-up: https://docs.conjure-up.io/
 conjure-up/(?P<page>.*): https://docs.conjure-up.io/{page}
 
 # snap-store-proxy
-snap-enterprise-proxy: /snap-store-proxy/en/
-snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
+snap-enterprise-proxy: https://canonical-snap-store-proxy.readthedocs-hosted.com/
+snap-enterprise-proxy/(?P<page>.*): https://canonical-snap-store-proxy.readthedocs-hosted.com/
+snap-store-proxy: https://canonical-snap-store-proxy.readthedocs-hosted.com/
+snap-store-proxy/(?P<page>.*): https://canonical-snap-store-proxy.readthedocs-hosted.com/
+
 
 # Landscape
 landscape/en/?: https://ubuntu.com/landscape/docs


### PR DESCRIPTION
## Done

- Removed snap-store-proxy from build-docs.sh
- Changed existing snap-enterprise-proxy redirect to RTD site
- Added redirects from old URL to RTD site
