### PR TITLE
Update build-docs.sh

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -61,27 +61,6 @@ build_docs () {
                             --tag-manager-code "GTM-KNX3CJC"  \
                             --no-link-extensions
     fi
-
-
-    # Snap Store Proxy docs
-    folder="build/snap-store-proxy"
-    name="snap-store-proxy"
-    repo_url="https://github.com/canonical-ols/snapstore-snap-docs.git"
-
-    if ! up_to_date ${folder} ${repo_url}; then
-      refresh_repo ${folder} ${repo_url} main
-
-      documentation-builder --base-directory "${folder}"  \
-                            --site-root "/${name}/"  \
-                            --output-path "templates/${name}"  \
-                            --output-media-path "static/media/${name}"  \
-                            --search-url "/search"  \
-                            --search-placeholder "Search Snap Store Proxy docs"  \
-                            --search-domain "docs.ubuntu.com/${name}"  \
-                            --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-KNX3CJC"  \
-                            --no-link-extensions
-    fi
 }
 
 build_docs


### PR DESCRIPTION
The snap store proxy docs are no longer published using documentation builder and the structure of the repo has changed. This step now causes the build to fail so we can't update the site

## Done

Removed building snap store proxy docs

## QA

check the build script succeeds


