### PR TITLE
change url for snap store proxy

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -90,7 +90,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Snapcraft Proxy">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://canonical-snap-store-proxy.readthedocs-hosted.com/en/latest">Snap Store Proxy&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://documentation.ubuntu.com/snap-store-proxy">Snap Store Proxy&nbsp;</a></h3>
             <div class="p-matrix__desc">
               <p>The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
             </div>


### PR DESCRIPTION
## Done

Changed link from https://canonical-snap-store-proxy.readthedocs-hosted.com/en/latest/ to https://documentation.ubuntu.com/snap-store-proxy for Snap Store Proxy on docs.ubuntu.com

## QA

Go to docs.ubuntu.com
Click on the link at Snap Store Proxy
Should be redirected to [https://documentation.ubuntu.com/snap-store-proxy](https://documentation.ubuntu.com/snap-store-proxy)

## Issue / Card

Fixes [#WD-14658](https://warthogs.atlassian.net/browse/WD-14658)

## Screenshots

[if relevant, include a screenshot]
