### PR TITLE
index: add real-time ubuntu docs entry

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,7 @@ jobs:
         run: yarn lint-python
 
   test-python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/templates/index.html
+++ b/templates/index.html
@@ -261,7 +261,15 @@
             </div>
           </div>
         </li>
-        <li class="p-matrix__item"></li>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Real-time Ubuntu">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title"><a class="p-link" href="https://documentation.ubuntu.com/real-time/">Real-time Ubuntu</a></h3>
+            <div class="p-matrix__desc">
+              <p>Enterprise-grade real-time kernel for end-to-end security and reliability in time-bound workloads.</p>
+            </div>
+          </div>
+        </li>
         <li class="p-matrix__item"></li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

Added an entry for Real-time Ubuntu documentation in the landing page.

## QA

Verified that `./run` builds with no errors locally and rendered HTML is as expected.

## Issue / Card

N/A

## Screenshots

![image](https://github.com/user-attachments/assets/d6ab6871-5424-4862-a42b-27fef1131bc9)
