### PR TITLE
index: Add Chisel and Rockcraft to the index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -213,6 +213,24 @@
             </div>
           </div>
         </li>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Rockcraft">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title"><a class="p-link" href="https://documentation.ubuntu.com/rockcraft/en/stable/">Rockcraft&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>Rockcraft is a tool to create rocks – a new generation of secure, stable and OCI-compliant container images.</p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Chisel">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title"><a class="p-link" href="https://documentation.ubuntu.com/chisel/">Chisel&nbsp;</a></h3>
+            <div class="p-matrix__desc">
+              <p>A CLI tool for creating minimal Ubuntu filesystems.</p>
+            </div>
+          </div>
+        </li>
         <li class="p-matrix__item"></li>
         <li class="p-matrix__item"></li>
       </ul>


### PR DESCRIPTION
## Done
[Chisel](https://documentation.ubuntu.com/chisel/en/latest/) and [Rockcraft](https://documentation.ubuntu.com/rockcraft/en/stable/#) added to the index page.

## QA

Verified the build locally.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19634

## Screenshots

![Screenshot from 2025-02-25 09-24-53](https://github.com/user-attachments/assets/54a415ee-ff12-464a-b541-c22aac596575)

