### PR TITLE
feat: add the documentation table of products to page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -53,81 +53,81 @@
         </thead>
         <tbody>
           <!-- PLATFORMS -->
-          <tr style="background: rgba(0,0,0,0.1)">
+          <tr style="background: rgba(0,0,0,0.2);">
             <th><strong>Platform</strong></th>
-            <td><a href="https://canonical-kernos.readthedocs-hosted.com/">KernOS</a></td>
-            <td><a href="https://ubuntu.com/core/docs">Core</a></td>
+            <td></td>
+            <td><a href="https://documentation.ubuntu.com/real-time/en/latest/#">Real-time Ubuntu</a></td>
             <td><a href="https://help.ubuntu.com/lts/ubuntu-help/index.html">Ubuntu Desktop</a></td>
+            <td><a href="https://documentation.ubuntu.com/lxd/en/latest/">LXD</a></td>
+            <td><a href="https://charmed-kubeflow.io/docs">Canonical Kubeflow</a></td>
+            <td><a href="https://documentation.ubuntu.com/anbox-cloud/en/latest/">Anbox Cloud</a></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.2); border-top: 1px solid rgba(0,0,0,0.2);">
+            <th><strong></strong></th>
+            <td></td>
+            <td><a href="https://canonical-robotics.readthedocs-hosted.com/en/latest/">Robotics</a></td>
+            <td><a href="https://canonical-kernel-docs.readthedocs-hosted.com/en/latest/">Ubuntu Kernel</a></td>
+            <td><a href="https://multipass.run/docs">Multipass</a></td>
+            <td><a href="https://ubuntu.com/kubernetes/documentation">Canonical Kubernetes</a></td>
+            <td><a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/">MicroCloud</a></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.2); border-top: 1px solid rgba(0,0,0,0.2);">
+            <th><strong></strong></th>
+            <td></td>
+            <td><a href="https://ubuntu.com/core/docs">Ubuntu Core</a></td>
+            <td><a href="https://documentation.ubuntu.com/server/">Ubuntu Server</a></td>
             <td><a href="https://documentation.ubuntu.com/wsl/en/latest/">Ubuntu WSL</a></td>
-            <td>Charmed Kubernetes</td>
+            <td><a href="https://canonical-openstack.readthedocs-hosted.com/en/latest/">Canonical OpenStack</a></td>
             <td><a href="https://documentation.ubuntu.com/public-cloud/en/latest/">Public Cloud</a></td>
           </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
-            <th><strong></strong></th>
-            <td></td>
-            <td>Core Desktop</td>
-            <td>Ubuntu Server</td>
-            <td>LXD</td>
-            <td>Microk8s</td>
-            <td>Open Stack</td>
-          </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
-            <th><strong></strong></th>
-            <td></td>
-            <td>Robotics</td>
-            <td></td>
-            <td><a href="https://multipass.run/docs">Multipass</a></td>
-            <td><a href="https://charmed-kubeflow.io/docs">Kubeflow</a></td>
-            <td></td>
-          </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
-            <th><strong></strong></th>
-            <td></td>
-            <td>Matter</td>
-            <td></td>
-            <td></td>
-            <td><a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/">MicroCloud</a></td>
-            <td></td>
-          </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
+          <tr style="background: rgba(0,0,0,0.2); border-top: 1px solid rgba(0,0,0,0.2);">
             <th><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>
             <td></td>
-            <td><a href="https://documentation.ubuntu.com/anbox-cloud/en/latest/">Anbox Cloud</a></td>
-            <td></td>
-          </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
-            <th><strong></strong></th>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td>Canonical Kubernetes</td>
-            <td></td>
+            <td><a href="https://microk8s.io/docs">MicroK8s</a></td>
+            <td><a href="https://documentation.ubuntu.com/aws/en/latest/">Ubuntu on AWS</a></td>
           </tr>
           <!-- Management -->
-          <tr>
+          <tr style="background: rgba(0,0,0,0.15); border-top: 1px solid rgba(0,0,0,0.15);">
             <th><strong>Management</strong></th>
-            <td>Pebble</td>
-            <td><a href="https://snapcraft.io/docs">Snapd</a></td>
-            <td>Pro</td>
+            <td><a href="https://documentation.ubuntu.com/pebble/">Pebble</a></td>
+            <td><a href="https://snapcraft.io/docs">Snap</a></td>
+            <td><a href="https://ubuntu.com/landscape/docs">Landscape</a></td>
+            <td><a href="https://documentation.ubuntu.com/data-science-stack/en/latest/">Data Science Stack</a></td>
+            <td><a href="https://canonical-jaas-documentation.readthedocs-hosted.com/en/v3/">JAAS</a></td>
             <td></td>
-            <td>MAAS</td>
-            <td><a href="http://juju.is/docs/">Juju</a></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.15); border-top: 1px solid rgba(0,0,0,0.15);">
+            <th><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td><a href="https://documentation.ubuntu.com/pro/">Ubuntu Pro</a></td>
+            <td></td>
+            <td><a href="https://canonical-juju.readthedocs-hosted.com/en/3.6/">Juju</a></td>
+            <td></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.15); border-top: 1px solid rgba(0,0,0,0.15);">
+            <th><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><a href="https://maas.io/docs">MAAS</a></td>
+            <td></td>
           </tr>
           <!-- Store -->
-          <tr style="background: rgba(0,0,0,0.1)">
+          <tr style="background: rgba(0,0,0,0.1); border-top: 1px solid rgba(0,0,0,0.1);">
             <th><strong>Stores</strong></th>
-            <td>(Kern Store)</td>
-            <td>Snap Store</td>
-            <td>(App Store)</td>
-            <td>(Rock Store)</td>
+            <td></td>
+            <td><a href="https://dashboard.snapcraft.io/docs/index.html">Snap Store</a></td>
+            <td></td>
+            <td></td>
             <td></td>
             <td><a href="https://charmhub.io/">Charmhub</a></td>
           </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
+          <tr style="background: rgba(0,0,0,0.1); border-top: 1px solid rgba(0,0,0,0.1);">
             <th><strong></strong></th>
             <td></td>
             <td><a href="https://documentation.ubuntu.com/snap-store-proxy/">Snap Store Proxy</a></td>
@@ -137,59 +137,68 @@
             <td></td>
           </tr>
           <!-- Apps -->
-          <tr>
+          <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
             <th><strong>Apps</strong></th>
             <td></td>
-            <td><a href="https://mir-server.io/docs">mir/Frame</a></td>
-            <td>Landscape</td>
-            <td></td>
+            <td><a href="https://canonical-matter.readthedocs-hosted.com/en/latest/">Matter on Ubuntu</a></td>
+            <td><a href="https://documentation.ubuntu.com/adsys/en/latest/">ADSys</a></td>
+            <td><a href="https://dqlite.io/docs">dqlite</a></td>
             <td><a href="https://ubuntu.com/ceph/docs">Ceph</a></td>
+            <td><a href="https://documentation.ubuntu.com/authd/en/stable/">authd</a></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
+            <th><strong></strong></th>
+            <td></td>
+            <td><a href="https://mir-server.io/docs">Mir</a></td>
+            <td><a href="https://canonical-netplan.readthedocs-hosted.com/en/latest/">Netplan</a></td>
+            <td></td>
+            <td><a href="https://documentation.ubuntu.com/charmed-mlflow/en/latest/">Charmed MLflow</a></td>
             <td><a href="https://canonical.com/data/docs">Charmed Data</a></td>
           </tr>
-          <tr style="border-top: 1px solid #fff;">
+          <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
             <th><strong></strong></th>
             <td></td>
-            <td>cloud-init</td>
-            <td>Livepatch</td>
             <td></td>
-            <td><a href="https://canonical-microceph.readthedocs-hosted.com/en/reef-stable/">Microceph</a></td>
-            <td>dqlite</td>
+            <td></td>
+            <td></td>
+            <td><a href="https://canonical-microceph.readthedocs-hosted.com/en/reef-stable/">MicroCeph</a></td>
+            <td><a href="https://docs.cloud-init.io/en/latest/">cloud-init</a></td>
           </tr>
-          <tr style="border-top: 1px solid #fff;">
+          <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
             <th><strong></strong></th>
             <td></td>
             <td></td>
-            <td>Netplan</td>
             <td></td>
-            <td>OVN</td>
+            <td></td>
+            <td><a href="https://canonical-microovn.readthedocs-hosted.com/en/latest/">MicroOVN</a></td>
+            <td></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
+            <th><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><a href="https://canonical.com/microstack/docs">MicroStack</a></td>
             <td></td>
           </tr>
           <!-- Tools -->
-          <tr style="background: rgba(0,0,0,0.1)">
+          <tr style="border-top: 1px solid #fff;">
             <th><strong>Tools</strong></th>
-            <td><a href="https://canonical-kernos.readthedocs-hosted.com/en/latest/reference/kerncraft/">Kerncraft</a></td>
+            <td></td>
             <td><a href="https://snapcraft.io/docs/snapcraft">Snapcraft</a></td>
-            <td>Imagecraft</td>
+            <td><a href="https://documentation.ubuntu.com/chisel/en/latest/">Chisel</a></td>
             <td><a href="https://documentation.ubuntu.com/rockcraft/">Rockcraft</a></td>
-            <td><a href="https://documentation.ubuntu.com/launchpad/en/latest/">Launchpad</a></td>
             <td><a href="https://juju.is/docs/sdk/charmcraft">Charmcraft</a></td>
-          </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
-            <th><strong></strong></th>
-            <td></td>
-            <td>(Serial vault)</td>
-            <td></td>
-            <td><a href="https://canonical-workshop.readthedocs-hosted.com/en/latest/">Workshop</a>/<a href="https://canonical-sdkcraft.readthedocs-hosted.com/en/latest/">SDKcraft</a></td>
-            <td></td>
             <td></td>
           </tr>
-          <tr style="background: rgba(0,0,0,0.1)">
+          <tr style="border-top: 1px solid #fff;">
             <th><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>
-            <td>Chisel</td>
             <td></td>
+            <td><a href="https://documentation.ubuntu.com/launchpad/en/latest/">Launchpad</a></td>
             <td></td>
           </tr>
         </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,166 @@
   </div>
   <div class="p-strip">
     <div class="row">
+      <h2>Product Table</h2>
+      <table aria-label="Vanilla framework table example">
+        <thead>
+          <tr>
+            <th></th>
+            <th><strong>IoT/Edge</strong></th>
+            <th><strong>Embedded</strong></th>
+            <th><strong>Workstation</strong></th>
+            <th><strong>Containers</strong></th>
+            <th><strong>Data centre</strong></th>
+            <th><strong>Cloud</strong></th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- PLATFORMS -->
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong>Platform</strong></th>
+            <td><a href="https://canonical-kernos.readthedocs-hosted.com/">KernOS</a></td>
+            <td><a href="https://ubuntu.com/core/docs">Core</a></td>
+            <td><a href="https://help.ubuntu.com/lts/ubuntu-help/index.html">Ubuntu Desktop</a></td>
+            <td><a href="https://documentation.ubuntu.com/wsl/en/latest/">Ubuntu WSL</a></td>
+            <td>Charmed Kubernetes</td>
+            <td><a href="https://documentation.ubuntu.com/public-cloud/en/latest/">Public Cloud</a></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td>Core Desktop</td>
+            <td>Ubuntu Server</td>
+            <td>LXD</td>
+            <td>Microk8s</td>
+            <td>Open Stack</td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td>Robotics</td>
+            <td></td>
+            <td><a href="https://multipass.run/docs">Multipass</a></td>
+            <td><a href="https://charmed-kubeflow.io/docs">Kubeflow</a></td>
+            <td></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td>Matter</td>
+            <td></td>
+            <td></td>
+            <td><a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/">MicroCloud</a></td>
+            <td></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><a href="https://documentation.ubuntu.com/anbox-cloud/en/latest/">Anbox Cloud</a></td>
+            <td></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>Canonical Kubernetes</td>
+            <td></td>
+          </tr>
+          <!-- Management -->
+          <tr>
+            <th><strong>Management</strong></th>
+            <td>Pebble</td>
+            <td><a href="https://snapcraft.io/docs">Snapd</a></td>
+            <td>Pro</td>
+            <td></td>
+            <td>MAAS</td>
+            <td><a href="http://juju.is/docs/">Juju</a></td>
+          </tr>
+          <!-- Store -->
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong>Stores</strong></th>
+            <td>(Kern Store)</td>
+            <td>Snap Store</td>
+            <td>(App Store)</td>
+            <td>(Rock Store)</td>
+            <td></td>
+            <td><a href="https://charmhub.io/">Charmhub</a></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td><a href="https://documentation.ubuntu.com/snap-store-proxy/">Snap Store Proxy</a></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <!-- Apps -->
+          <tr>
+            <th><strong>Apps</strong></th>
+            <td></td>
+            <td><a href="https://mir-server.io/docs">mir/Frame</a></td>
+            <td>Landscape</td>
+            <td></td>
+            <td><a href="https://ubuntu.com/ceph/docs">Ceph</a></td>
+            <td><a href="https://canonical.com/data/docs">Charmed Data</a></td>
+          </tr>
+          <tr style="border-top: 1px solid #fff;">
+            <th><strong></strong></th>
+            <td></td>
+            <td>cloud-init</td>
+            <td>Livepatch</td>
+            <td></td>
+            <td><a href="https://canonical-microceph.readthedocs-hosted.com/en/reef-stable/">Microceph</a></td>
+            <td>dqlite</td>
+          </tr>
+          <tr style="border-top: 1px solid #fff;">
+            <th><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td>Netplan</td>
+            <td></td>
+            <td>OVN</td>
+            <td></td>
+          </tr>
+          <!-- Tools -->
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong>Tools</strong></th>
+            <td><a href="https://canonical-kernos.readthedocs-hosted.com/en/latest/reference/kerncraft/">Kerncraft</a></td>
+            <td><a href="https://snapcraft.io/docs/snapcraft">Snapcraft</a></td>
+            <td>Imagecraft</td>
+            <td><a href="https://documentation.ubuntu.com/rockcraft/">Rockcraft</a></td>
+            <td><a href="https://documentation.ubuntu.com/launchpad/en/latest/">Launchpad</a></td>
+            <td><a href="https://juju.is/docs/sdk/charmcraft">Charmcraft</a></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td>(Serial vault)</td>
+            <td></td>
+            <td><a href="https://canonical-workshop.readthedocs-hosted.com/en/latest/">Workshop</a>/<a href="https://canonical-sdkcraft.readthedocs-hosted.com/en/latest/">SDKcraft</a></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.1)">
+            <th><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>Chisel</td>
+            <td></td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="p-strip">
+    <div class="row">
       <h2>Our products</h2>
     </div>
     <div class="row">

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,14 +31,13 @@
   <div class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-8">
-        <h1>Ubuntu documentation</h1>
-        <p>The docs directory for all Ubuntu operating systems and products.</p>
+        <h1>Documentation directory</h1>
+        <p>The documentation directory for all Ubuntu operating systems and products.</p>
       </div>
     </div>
   </div>
   <div class="p-strip">
     <div class="row">
-      <h2>Product Table</h2>
       <table aria-label="Vanilla framework table example">
         <thead>
           <tr>
@@ -54,7 +53,7 @@
         <tbody>
           <!-- PLATFORMS -->
           <tr style="background: rgba(0,0,0,0.2);">
-            <th><strong>Platform</strong></th>
+            <th style="background: rgba(255, 255, 255, 1)"><strong>Platform</strong></th>
             <td></td>
             <td><a href="https://documentation.ubuntu.com/real-time/en/latest/#">Real-time Ubuntu</a></td>
             <td><a href="https://help.ubuntu.com/lts/ubuntu-help/index.html">Ubuntu Desktop</a></td>
@@ -63,7 +62,7 @@
             <td><a href="https://documentation.ubuntu.com/anbox-cloud/en/latest/">Anbox Cloud</a></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.2); border-top: 1px solid rgba(0,0,0,0.2);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td><a href="https://canonical-robotics.readthedocs-hosted.com/en/latest/">Robotics</a></td>
             <td><a href="https://canonical-kernel-docs.readthedocs-hosted.com/en/latest/">Ubuntu Kernel</a></td>
@@ -72,7 +71,7 @@
             <td><a href="https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/">MicroCloud</a></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.2); border-top: 1px solid rgba(0,0,0,0.2);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td><a href="https://ubuntu.com/core/docs">Ubuntu Core</a></td>
             <td><a href="https://documentation.ubuntu.com/server/">Ubuntu Server</a></td>
@@ -81,7 +80,7 @@
             <td><a href="https://documentation.ubuntu.com/public-cloud/en/latest/">Public Cloud</a></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.2); border-top: 1px solid rgba(0,0,0,0.2);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>
@@ -91,7 +90,7 @@
           </tr>
           <!-- Management -->
           <tr style="background: rgba(0,0,0,0.15); border-top: 1px solid rgba(0,0,0,0.15);">
-            <th><strong>Management</strong></th>
+            <th style="background: rgba(255, 255, 255, 1)"><strong>Management</strong></th>
             <td><a href="https://documentation.ubuntu.com/pebble/">Pebble</a></td>
             <td><a href="https://snapcraft.io/docs">Snap</a></td>
             <td><a href="https://ubuntu.com/landscape/docs">Landscape</a></td>
@@ -100,7 +99,7 @@
             <td></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.15); border-top: 1px solid rgba(0,0,0,0.15);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td></td>
             <td><a href="https://documentation.ubuntu.com/pro/">Ubuntu Pro</a></td>
@@ -109,7 +108,7 @@
             <td></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.15); border-top: 1px solid rgba(0,0,0,0.15);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>
@@ -119,7 +118,7 @@
           </tr>
           <!-- Store -->
           <tr style="background: rgba(0,0,0,0.1); border-top: 1px solid rgba(0,0,0,0.1);">
-            <th><strong>Stores</strong></th>
+            <th style="background: rgba(255, 255, 255, 1)"><strong>Stores</strong></th>
             <td></td>
             <td><a href="https://dashboard.snapcraft.io/docs/index.html">Snap Store</a></td>
             <td></td>
@@ -128,7 +127,7 @@
             <td><a href="https://charmhub.io/">Charmhub</a></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.1); border-top: 1px solid rgba(0,0,0,0.1);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td><a href="https://documentation.ubuntu.com/snap-store-proxy/">Snap Store Proxy</a></td>
             <td></td>
@@ -138,7 +137,7 @@
           </tr>
           <!-- Apps -->
           <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
-            <th><strong>Apps</strong></th>
+            <th style="background: rgba(255, 255, 255, 1)"><strong>Apps</strong></th>
             <td></td>
             <td><a href="https://canonical-matter.readthedocs-hosted.com/en/latest/">Matter on Ubuntu</a></td>
             <td><a href="https://documentation.ubuntu.com/adsys/en/latest/">ADSys</a></td>
@@ -147,7 +146,7 @@
             <td><a href="https://documentation.ubuntu.com/authd/en/stable/">authd</a></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td><a href="https://mir-server.io/docs">Mir</a></td>
             <td><a href="https://canonical-netplan.readthedocs-hosted.com/en/latest/">Netplan</a></td>
@@ -156,7 +155,7 @@
             <td><a href="https://canonical.com/data/docs">Charmed Data</a></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>
@@ -165,7 +164,7 @@
             <td><a href="https://docs.cloud-init.io/en/latest/">cloud-init</a></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>
@@ -174,7 +173,7 @@
             <td></td>
           </tr>
           <tr style="background: rgba(0,0,0,0.05); border-top: 1px solid rgba(0,0,0,0.05);">
-            <th><strong></strong></th>
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>
@@ -183,8 +182,8 @@
             <td></td>
           </tr>
           <!-- Tools -->
-          <tr style="border-top: 1px solid #fff;">
-            <th><strong>Tools</strong></th>
+          <tr style="background: rgba(0,0,0,0.025); border-top: 1px solid rgba(0,0,0,0.025);">
+            <th style="background: rgba(255, 255, 255, 1);  border-right: 1px solid rgba(0,0,0,0.05);"><strong>Tools</strong></th>
             <td></td>
             <td><a href="https://snapcraft.io/docs/snapcraft">Snapcraft</a></td>
             <td><a href="https://documentation.ubuntu.com/chisel/en/latest/">Chisel</a></td>
@@ -192,8 +191,8 @@
             <td><a href="https://juju.is/docs/sdk/charmcraft">Charmcraft</a></td>
             <td></td>
           </tr>
-          <tr style="border-top: 1px solid #fff;">
-            <th><strong></strong></th>
+          <tr style="background: rgba(0,0,0,0.025); border-top: 1px solid rgba(0,0,0,0.025);">
+            <th style="background: rgba(255, 255, 255, 1)"><strong></strong></th>
             <td></td>
             <td></td>
             <td></td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -113,6 +113,15 @@
             <td></td>
             <td></td>
             <td></td>
+            <td><a href="https://documentation.ubuntu.com/launchpad/en/latest/">Launchpad</a></td>
+            <td></td>
+          </tr>
+          <tr style="background: rgba(0,0,0,0.15); border-top: 1px solid rgba(0,0,0,0.15);">
+            <th style="background: rgba(255, 255, 255, 1); border-top: 1px solid rgba(255,255,255,1)"><strong></strong></th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
             <td><a href="https://maas.io/docs">MAAS</a></td>
             <td></td>
           </tr>
@@ -189,15 +198,6 @@
             <td><a href="https://documentation.ubuntu.com/chisel/en/latest/">Chisel</a></td>
             <td><a href="https://documentation.ubuntu.com/rockcraft/">Rockcraft</a></td>
             <td><a href="https://juju.is/docs/sdk/charmcraft">Charmcraft</a></td>
-            <td></td>
-          </tr>
-          <tr style="background: rgba(0,0,0,0.025); border-top: 1px solid rgba(0,0,0,0.025);">
-            <th style="background: rgba(255, 255, 255, 1)"><strong></strong></th>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td><a href="https://documentation.ubuntu.com/launchpad/en/latest/">Launchpad</a></td>
             <td></td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Done

Added Product Table requested from the TA [Epic](https://warthogs.atlassian.net/browse/DOCPR-960?atlOrigin=eyJpIjoiZDUzMWUzZjllZDM2NGFmYzllMTcxOTgwMzk3YzVlYWIiLCJwIjoiaiJ9) based on the following [file](https://docs.google.com/spreadsheets/d/1HxWy9mNdsuAeo6C6I1h-w5McmKrgL8GP9p5ybDFP7mE/edit?gid=389860526#gid=389860526)

## QA

Check all the spreadsheet link work in the same way as the Table in docs.u.com

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
