### PR TITLE
WD-20520 fix: Replace Snap Store Proxy with Enterprise Store

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-{% extends 'includes/layout.html' %} 
+{% extends 'includes/layout.html' %}
 
 {% block meta_description %}The docs directory for all Ubuntu operating systems and products.{% endblock %}
 
@@ -88,11 +88,11 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Snapcraft Proxy">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3cefa82a-Snapcraft+Proxy_Aubergine.svg" alt="Enterprise Store">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://documentation.ubuntu.com/snap-store-proxy">Snap Store Proxy&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://documentation.ubuntu.com/enterprise-store/">Enterprise Store&nbsp;</a></h3>
             <div class="p-matrix__desc">
-              <p>The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
+              <p>The Enterprise Store provides an on-premise edge proxy to the Snap Store for your devices</p>
             </div>
           </div>
         </li>


### PR DESCRIPTION
## Done

Replace Snap Store Proxy with Enterprise Store

## QA

- Check there are no references to Snap Store Proxy anymore
- Check the link works

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-20520
