### PR TITLE
Use overflow:auto on the tables container

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
     </div>
   </div>
   <div class="p-strip">
-    <div class="row"  style="display: flex; flex-flow: column; overflow-x: scroll;">
+    <div class="row"  style="display: flex; flex-flow: column; overflow-x: auto;">
       <table aria-label="Vanilla framework table example" style="min-width: 800px;">
         <thead>
           <tr>


### PR DESCRIPTION
## Done

- Uses `overflow-x:auto` on the main tables container to hide the scroll bar when it isn't needed

## QA

- Open [the demo](https://docs-ubuntu-com-386.demos.haus/)
- See there is no scroll bar below the table
- Open on small screen, see the scroll bar apears
