### PR TITLE
update links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -57,7 +57,7 @@
             <td></td>
             <td><a href="https://canonical-robotics.readthedocs-hosted.com/en/latest/">Robotics</a></td>
             <td><a href="https://canonical-kernel-docs.readthedocs-hosted.com/en/latest/">Ubuntu Kernel</a></td>
-            <td><a href="https://multipass.run/docs">Multipass</a></td>
+            <td><a href="https://documentation.ubuntu.com/multipass/en/latest">Multipass</a></td>
             <td><a href="https://documentation.ubuntu.com/canonical-kubernetes/latest/">Canonical Kubernetes</a></td>
             <td><a href="https://documentation.ubuntu.com/microcloud">MicroCloud</a></td>
           </tr>
@@ -84,7 +84,7 @@
             <td><a href="https://snapcraft.io/docs">Snap</a></td>
             <td><a href="https://ubuntu.com/landscape/docs">Landscape</a></td>
             <td><a href="https://documentation.ubuntu.com/data-science-stack/en/latest/">Data Science Stack</a></td>
-            <td><a href="https://canonical-jaas-documentation.readthedocs-hosted.com/en/v3/">JAAS</a></td>
+            <td><a href="https://documentation.ubuntu.com/jaas/v3/">JAAS</a></td>
             <td></td>
           </tr>
           <tr>
@@ -108,7 +108,7 @@
             <td></td>
             <td></td>
             <td></td>
-            <td><a href="https://maas.io/docs">MAAS</a></td>
+            <td><a href="https://canonical.com/maas/docs">MAAS</a></td>
             <td></td>
           </tr>
           <!-- Store -->
@@ -194,7 +194,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="MAAS">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://maas.io/docs">MAAS&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://canonical.com/maas/docs">MAAS&nbsp;</a></h3>
             <div class="p-matrix__desc">
               <p>Create a bare-metal cloud with Metal as a Service for IPAM and provisioning</p>
             </div>
@@ -257,7 +257,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg" alt="Multipass">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://multipass.run/docs">Multipass&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://documentation.ubuntu.com/multipass/en/latest">Multipass&nbsp;</a></h3>
             <div class="p-matrix__desc">
               <p>Ubuntu virtual machines on demand for Linux, MacOS and Windows</p>
             </div>


### PR DESCRIPTION
## Done
1. Update MAAS Link to https://canonical.com/maas/docs
2. Update Multipass link to https://documentation.ubuntu.com/multipass/en/latest
3. Update broken JAAS link to https://documentation.ubuntu.com/jaas/v3/
## QA

- Check the demo is working correctly and the 3 links redirect to the correct documentations

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
