### PR TITLE
Update site favicon(s)

### DIFF
--- a/templates/includes/layout.html
+++ b/templates/includes/layout.html
@@ -17,15 +17,15 @@
   <!-- End Google Tag Manager -->
 
   <meta charset="UTF-8" />
-  <link rel="icon" href="{{ ASSET_SERVER_URL }}8d4630a6-pictogram-heart-mid-grey.svg">
   <title>Ubuntu documentation</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="The docs directory for all Ubuntu operating systems and products." />
   <link rel="stylesheet" href="{% versioned_static 'css/main.css' %}" />
   <!-- Serving favicon for search engines locally -->
-  <link rel="icon" type="image/png" sizes="48x48" href="{% versioned_static 'favicons/COF-favicon-48x48.png' %}" />
-  <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}16c27f81-COF%2520favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}be7e4cc6-COF-favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}6ead207a-COF-favicon-48x48.png" sizes="48x48" />
+  <link rel="apple-touch-icon" type="image/png" href="{{ ASSET_SERVER_URL }}f38b9c7e-COF%2520apple-touch-icon.png" sizes="180x180" />
 </head>
 
 <body>


### PR DESCRIPTION
## Done

* Removed 'heart' icon (why was it ever there?)
* Updated other favicon definitions to new Ubuntu CoF
* Added such favicon definitions as used on ubuntu.com
