### PR TITLE
Add observability to the home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,6 +119,14 @@
             <td><a href="https://canonical.com/maas/docs">MAAS</a></td>
             <td></td>
           </tr>
+          <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><a href="https://documentation.ubuntu.com/observability">Observability</a></td>
+            <td></td>
+          </tr>
           <!-- Store -->
           <tr style="border-top: 1px solid rgba(0,0,0,0.2);">
             <th rowspan="2" scope="rowgroup"><strong>Stores</strong></th>


### PR DESCRIPTION
Adding Observability under **Management / Data Centre**. The other location I discussed with that team could be under **Apps/Cloud**, next to "Charmed data"

**For reviewer:**
- Can you test this? I didn't test it, although it's straightforward so I doubt there would be issues. I couldn't get Docker set up right to test it locally and didn't want to sink tons of time into that when I contribute to this project so infrequently and the change is straightforward / UI-only