### PR TITLE
templates: update URL for kernel docs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -56,7 +56,7 @@
           <tr>
             <td></td>
             <td><a href="https://canonical-robotics.readthedocs-hosted.com/en/latest/">Robotics</a></td>
-            <td><a href="https://canonical-kernel-docs.readthedocs-hosted.com/en/latest/">Ubuntu Kernel</a></td>
+            <td><a href="https://canonical-kernel-docs.readthedocs-hosted.com/">Ubuntu Kernel</a></td>
             <td><a href="https://documentation.ubuntu.com/multipass/en/latest">Multipass</a></td>
             <td><a href="https://documentation.ubuntu.com/canonical-kubernetes/latest/">Canonical Kubernetes</a></td>
             <td><a href="https://documentation.ubuntu.com/microcloud">MicroCloud</a></td>


### PR DESCRIPTION
Kernel docs no longer has the version and language scheme in the URL. Updated the link to minimize the redirects.

## Done

Update the templates/index.html to remove the language and versioning scheme for the Kernel docs URL.

## QA

No bug; just housekeeping.

## Issue / Card

No issue; just housekeeping.

## Screenshots

N/A
