### PR TITLE
add: Workshop docs link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user Cython==0.29.
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:16 AS yarn-dependencies
+FROM node:18 AS yarn-dependencies
 WORKDIR /srv
 COPY . .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install

--- a/templates/index.html
+++ b/templates/index.html
@@ -99,7 +99,7 @@
             <td></td>
             <td></td>
             <td><a href="https://documentation.ubuntu.com/pro/">Ubuntu Pro</a></td>
-            <td></td>
+            <td><a href="https://ubuntu.com/workshop/docs/">Workshop</a></td>
             <td><a href="https://juju.is/docs">Juju</a></td>
             <td></td>
           </tr>


### PR DESCRIPTION
## Done

 - Added Workshop docs link to the index table

## QA

 - Visit the homepage index table and confirm the Workshop cell links to https://ubuntu.com/workshop/docs/

## Issue / Card

N/A

## Screenshots

N/A
