### PR TITLE
fix: update Anbox Cloud docs link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
             <td><a href="https://documentation.ubuntu.com/desktop/">Ubuntu Desktop</a></td>
             <td><a href="https://documentation.ubuntu.com/lxd/en/latest/">LXD</a></td>
             <td><a href="https://charmed-kubeflow.io/docs">Canonical Kubeflow</a></td>
-            <td><a href="https://documentation.ubuntu.com/anbox-cloud/en/latest/">Anbox Cloud</a></td>
+            <td><a href="https://canonical.com/anbox-cloud/docs/">Anbox Cloud</a></td>
           </tr>
           <tr>
             <td></td>
@@ -345,7 +345,7 @@
         <li class="p-matrix__item">
           <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/2d850f3f-CoF%2520Circle%2520New.svg" alt="Anbox Cloud">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link" href="https://anbox-cloud.io/docs">Anbox Cloud&nbsp;</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link" href="https://canonical.com/anbox-cloud/docs/">Anbox Cloud&nbsp;</a></h3>
             <div class="p-matrix__desc">
               <p>Enables running Android apps on any cloud platform at scale</p>
             </div>


### PR DESCRIPTION
## Done

Updated Anbox Cloud docs link in the index table to point to the new canonical domain

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
