### PR TITLE
fix: update Chisel link to point to the canonical domain

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -192,7 +192,7 @@
             <th scope="row"><strong>Tools</strong></th>
             <td></td>
             <td><a href="https://documentation.ubuntu.com/snapcraft/">Snapcraft</a></td>
-            <td><a href="https://documentation.ubuntu.com/chisel/en/latest/">Chisel</a></td>
+            <td><a href="https://ubuntu.com/chisel/docs/latest/">Chisel</a></td>
             <td><a href="https://documentation.ubuntu.com/rockcraft/">Rockcraft</a></td>
             <td><a href="https://canonical-charmcraft.readthedocs-hosted.com">Charmcraft</a></td>
             <td></td>


### PR DESCRIPTION
## Done

Updated the Chisel docs link in the index table

## QA



## Issue / Card


## Screenshots

