### PR TITLE
update Pebble link in index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -88,7 +88,7 @@
           <!-- Management -->
           <tr style="border-top: 1px solid rgba(0,0,0,0.2);">
             <th rowspan="5" scope="rowgroup"><strong>Management</strong></th>
-            <td><a href="https://documentation.ubuntu.com/pebble/">Pebble</a></td>
+            <td><a href="https://ubuntu.com/docs/pebble/">Pebble</a></td>
             <td><a href="https://snapcraft.io/docs">Snap</a></td>
             <td><a href="https://documentation.ubuntu.com/landscape/">Landscape</a></td>
             <td><a href="https://documentation.ubuntu.com/data-science-stack/en/latest/">Data Science Stack</a></td>


### PR DESCRIPTION
This PR updates the URL of the Pebble link after we migrated the docs to ubuntu.com.