### PR TITLE
Update LXD docs URL following docs migration

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -49,7 +49,7 @@
             <td></td>
             <td><a href="https://documentation.ubuntu.com/real-time/en/latest/#">Real-time Ubuntu</a></td>
             <td><a href="https://documentation.ubuntu.com/desktop/">Ubuntu Desktop</a></td>
-            <td><a href="https://documentation.ubuntu.com/lxd/en/latest/">LXD</a></td>
+            <td><a href="https://canonical.com/lxd/docs/latest/">LXD</a></td>
             <td><a href="https://charmed-kubeflow.io/docs">Canonical Kubeflow</a></td>
             <td><a href="https://canonical.com/anbox-cloud/docs/">Anbox Cloud</a></td>
           </tr>


### PR DESCRIPTION
## Done

Updates LXD docs URL to canonical.com/lxd/docs/latest/.
